### PR TITLE
Fixed Tactical Transient classes

### DIFF
--- a/LWOTC_AlienPack/Config/XComGame.ini
+++ b/LWOTC_AlienPack/Config/XComGame.ini
@@ -6,10 +6,3 @@ DLCIdentifier="LWOTC_AlienPack"
 +droneNames="LWDroneM2"
 +droneNames="AdvDroneM1"
 +droneNames="AdvDroneM2"
-
-[XComGame.XComGameInfo]
-;Transient tactical classes specify objects that should be set as removed in the history upon leaving a tactical session
-+TransientTacticalClassNames=XComGameState_Unit_AlienCustomization
-+TransientTacticalClassNames=XComGameState_Effect_EffectCounter_AP
-+TransientTacticalClassNames=XComGameState_Effect_IncomingReactionFire_AP
-+TransientTacticalClassNames=XComGameState_Effect_LastShotDetails_AP

--- a/LWOTC_AlienPack/Src/LWOTC_AlienPack/Classes/XComGameState_AlienCustomizationManager.uc
+++ b/LWOTC_AlienPack/Src/LWOTC_AlienPack/Classes/XComGameState_AlienCustomizationManager.uc
@@ -279,3 +279,8 @@ function UpdateAllCustomizations()
 	//
 	//return ELR_NoInterrupt;
 //}
+
+defaultproperties
+{
+	bTacticalTransient=true
+}

--- a/LWOTC_AlienPack/Src/LWOTC_AlienPack/Classes/XComGameState_Effect_EffectCounter_AP.uc
+++ b/LWOTC_AlienPack/Src/LWOTC_AlienPack/Classes/XComGameState_Effect_EffectCounter_AP.uc
@@ -50,3 +50,8 @@ simulated function EventListenerReturn IncrementUses(Object EventData, Object Ev
 	`TACTICALRULES.SubmitGameState(NewGameState);
 	return ELR_NoInterrupt;
 }
+
+defaultproperties
+{
+	bTacticalTransient=true
+}

--- a/LWOTC_AlienPack/Src/LWOTC_AlienPack/Classes/XComGameState_Effect_IncomingReactionFire_AP.uc
+++ b/LWOTC_AlienPack/Src/LWOTC_AlienPack/Classes/XComGameState_Effect_IncomingReactionFire_AP.uc
@@ -92,3 +92,8 @@ simulated function EventListenerReturn ResetFlyover(Object EventData, Object Eve
   }
   return ELR_NoInterrupt;
 }
+
+defaultproperties
+{
+	bTacticalTransient=true
+}

--- a/LWOTC_AlienPack/Src/LWOTC_AlienPack/Classes/XComGameState_Effect_LastShotDetails_AP.uc
+++ b/LWOTC_AlienPack/Src/LWOTC_AlienPack/Classes/XComGameState_Effect_LastShotDetails_AP.uc
@@ -57,3 +57,8 @@ simulated function EventListenerReturn RecordShot(Object EventData, Object Event
 	}
 	return ELR_NoInterrupt;
 }
+
+defaultproperties
+{
+	bTacticalTransient=true
+}


### PR DESCRIPTION
Fix for Issue #31 

Set bTacticalTransient to true in tactical transient gamestate classes. Removed TransientTacticalClassNames entries in XComGame.ini, since they are no longer used.