### PR TITLE
Updated X2Action_MoveClimbWall override

### DIFF
--- a/LWOTC_AlienPack/Config/XComEngine.ini
+++ b/LWOTC_AlienPack/Config/XComEngine.ini
@@ -1,9 +1,9 @@
-[UnrealEd.EditorEngine]
-!ModEditPackages=()
-
 [Engine.ScriptPackages]
 +NonNativePackages=LWOTC_AlienPack
++NonNativePackages=WallClimbOverride
+
+[UnrealEd.EditorEngine]
++EditPackages=WallClimbOverride
 
 [Engine.Engine]
-; requires patch 5 static function override
-+ModClassOverrides=(BaseGameClass="X2Action_MoveClimbWall", ModClass="X2Action_MoveClimbWall_LW")
++ModClassOverrides=(BaseGameClass="X2Action_MoveClimbWall", ModClass="WallClimbOverride.X2Action_MoveClimbWall_Override")

--- a/LWOTC_AlienPack/LWOTC_AlienPack.x2proj
+++ b/LWOTC_AlienPack/LWOTC_AlienPack.x2proj
@@ -256,9 +256,6 @@
     <Content Include="Src\LWOTC_AlienPack\Classes\X2Ability_PPAlienAbilities.uc">
       <SubType>Content</SubType>
     </Content>
-    <Content Include="Src\LWOTC_AlienPack\Classes\X2Action_MoveClimbWall_LW.uc">
-      <SubType>Content</SubType>
-    </Content>
     <Content Include="Src\LWOTC_AlienPack\Classes\X2Character_AlienPack.uc">
       <SubType>Content</SubType>
     </Content>
@@ -343,6 +340,9 @@
     <Content Include="Src\LWOTC_AlienPack\Classes\XComGameState_Unit_AlienCustomization.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\WallClimbOverride\Classes\X2Action_MoveClimbWall_Override.uc">
+      <SubType>Content</SubType>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Config\" />
@@ -352,6 +352,8 @@
     <Folder Include="Src\" />
     <Folder Include="Src\LWOTC_AlienPack" />
     <Folder Include="Src\LWOTC_AlienPack\Classes" />
+    <Folder Include="Src\WallClimbOverride" />
+    <Folder Include="Src\WallClimbOverride\Classes" />
   </ItemGroup>
   <Import Project="$(MSBuildLocalExtensionPath)\XCOM2.targets" />
 </Project>

--- a/LWOTC_AlienPack/Src/WallClimbOverride/Classes/X2Action_MoveClimbWall_Override.uc
+++ b/LWOTC_AlienPack/Src/WallClimbOverride/Classes/X2Action_MoveClimbWall_Override.uc
@@ -1,7 +1,7 @@
 //-----------------------------------------------------------
 // Used by the visualizer system to control a Visualization Actor
 //-----------------------------------------------------------
-class X2Action_MoveClimbWall_LW extends X2Action_MoveClimbWall;
+class X2Action_MoveClimbWall_Override extends X2Action_MoveClimbWall;
 
 //var vector  Destination;
 //var vector	Source;


### PR DESCRIPTION
Addresses Issue #32 

Renamed X2Action_MoveClimbWall_LW to X2Action_MoveClimbWall_Override and moved it into its own package, WallClimbOverride. This will improve compatibility with other mods that also override X2Action_MoveClimbWall in the same manner.